### PR TITLE
Weird behaviour in Rails 3 (production and test)

### DIFF
--- a/lib/simple_autocomplete.rb
+++ b/lib/simple_autocomplete.rb
@@ -5,9 +5,8 @@ end
 # see Readme for details
 class ActionController::Base
   def self.autocomplete_for(object, method, options = {}, &block)
-    options = options.dup
     define_method("autocomplete_for_#{object}_#{method}") do
-      methods = options.delete(:match) || [*method]
+      methods = options[:match] || [*method]
       condition = methods.map{|m| "LOWER(#{m}) LIKE ?"} * " OR "
       values = methods.map{|m| "%#{params[:q].to_s.downcase}%"}
       conditions = [condition, *values]
@@ -17,7 +16,7 @@ class ActionController::Base
         :conditions => conditions,
         :order => "#{methods.first} ASC",
         :limit => 10
-        }.merge!(options)
+        }.merge!(options.except(:match))
 
       @items = model.scoped(find_options)
 


### PR DESCRIPTION
When I use in a controller something like this:

<code>autocomplete_for(:customer, :name, :match => ['name', 'lastname'])</code>

The first time I do a request everything is right, but the second only search in the default field (name in this case). Digging a bit in the code I found that you use options.delete(:match), this for some reason gets cached or modifies the original (I really don't understand the background of this behaviour) despite the options.dup.

The changes I made only avoid the modification of the options argument and everything works as expected.

Thank you for this great plugin, regards.

Franco Catena.
